### PR TITLE
added coercion methods to be able to coerce SummarizedExperiment to …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Collate:
     'aboutLoop.R'
     'classValid.R'
     'allClass.R'
+    'coercion.R'
     'aggValue.R'
     'allGenerics.R'
     'changeTree.R'

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -1,0 +1,25 @@
+
+.sce_to_tse <- function(sce){
+    tse <- new("TreeSummarizedExperiment",
+               sce,
+               rowTree = NULL,
+               colTree = NULL,
+               rowLinks = NULL,
+               colLinks = NULL)
+    tse
+}
+
+#' @importClassesFrom SingleCellExperiment SingleCellExperiment
+setAs("SingleCellExperiment", "TreeSummarizedExperiment",function(from) {
+    .sce_to_tse(from)
+})
+
+#' @importClassesFrom SummarizedExperiment SummarizedExperiment
+setAs("SummarizedExperiment", "TreeSummarizedExperiment",function(from) {
+    .sce_to_tse(as(from,"SingleCellExperiment"))
+})
+
+#' @importClassesFrom SummarizedExperiment RangedSummarizedExperiment
+setAs("RangedSummarizedExperiment", "TreeSummarizedExperiment",function(from) {
+    .sce_to_tse(as(from,"SingleCellExperiment"))
+})

--- a/tests/testthat/test-Accessor-Constructor.R
+++ b/tests/testthat/test-Accessor-Constructor.R
@@ -37,9 +37,25 @@ test_that("TreeSummarizedExperiment constuctor works", {
                     "TreeSummarizedExperiment")
 
     expect_warning(TreeSummarizedExperiment(assays = list(toyTable),
-                                          rowData = rowInf,
-                                          colData = colInf,
-                                          colTree = tinyTree))
+                                            rowData = rowInf,
+                                            colData = colInf,
+                                            colTree = tinyTree))
+})
+test_that("TreeSummarizedExperiment coercion works", {
+    # SummarizedExperiment
+    se <- SummarizedExperiment(assays = list(toyTable),
+                               rowData = rowInf,
+                               colData = colInf)
+    expect_s4_class(as(se,"TreeSummarizedExperiment"),
+                    "TreeSummarizedExperiment")
+    # RangedSummarizedExperiment
+    expect_s4_class(as(as(se,"RangedSummarizedExperiment"),
+                       "TreeSummarizedExperiment"),
+                    "TreeSummarizedExperiment")
+    # RangedSummarizedExperiment
+    expect_s4_class(as(as(se,"SingleCellExperiment"),
+                       "TreeSummarizedExperiment"),
+                    "TreeSummarizedExperiment")
 })
 
 
@@ -85,7 +101,7 @@ test_that("subsetting by node successfully", {
     expect_equal(nrow(subsetByNode(tse,"t2")),1L)
     expect_equal(subsetByNode(tse,"t2"),
                  subsetByNode(tse,1))
-    
+
     expect_equal(ncol(subsetByNode(tse, colNode = "A_1")),1L)
     expect_equal(subsetByNode(tse, colNode = "A_1"),
                  subsetByNode(tse, colNode = 1))
@@ -127,7 +143,7 @@ test_that("other setters work", {
     expect_true(all(rownames(colLinks(tse)) != cn))
     colnames(tse) <- cn
     expect_true(all(rownames(colLinks(tse)) == cn))
-    
+
     tse <- TreeSummarizedExperiment(assays = list(toyTable),
                                     rowData = rowInf,
                                     colData = colInf)


### PR DESCRIPTION
…TreeSummarizedExperiment directly.

Example:
```
se <- SummarizedExperiment(assays = list(toyTable),
                           rowData = rowInf,
                           colData = colInf)
```

Starting from the `se` object given above, currently this needs to be done:
```
as(as(se,"SingleCellExperiment"),
   "TreeSummarizedExperiment")
```
This only works because R constructs a coercion methods on the fly, since `TSE` directly inherits from `SCE`. This works only one level down, apparently.

Now this works directly
```
as(se, "TreeSummarizedExperiment")
```

